### PR TITLE
Make scan_name hostfile register configurable and prevent profile ping ping

### DIFF
--- a/files/etc_profile
+++ b/files/etc_profile
@@ -65,3 +65,4 @@ if [ $USER = "oracle" ] || [ $USER = "grid" ]; then
         ulimit -u 16384 -n 65536
     fi
 fi
+alias vi='vim'

--- a/manifests/hosts.pp
+++ b/manifests/hosts.pp
@@ -64,14 +64,20 @@ class ora_rac::hosts inherits ora_rac::params
   }
 
   #
-  # Set the virtual private IP hostname
+  # Register SCAN name in hostfile
   #
-  if $scan_name {
+  if $scan_name_in_hostfile {
     host{"${scan_name}.${::domain}":
+      ensure       => present,
       host_aliases => $scan_name,
       ip           => $scan_adresses,
     }
   } else {
-    notice('Scan name not defined by puppet.Be sure it is in the DNS')
+    host{"${scan_name}.${::domain}":
+      ensure       => absent,
+      host_aliases => $scan_name,
+      ip           => $scan_adresses,
+    }
+    notice('SCAN name not defined in hostfile by puppet. Be sure it is in the DNS')
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class ora_rac::params(
   $password                   = 'manager123',
   $scan_name                  = 'scan',
   $scan_port                  = 1521,
+  $scan_name_in_hostfile      = true,
   $crs_disk_group_name        = 'CRS',
   $crs_disk                   = 'ORCL:CRSVOL1,ORCL:CRSVOL2,ORCL:CRSVOL3',
   $data_disk_group_name       = 'DATA',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "enterprisemodules-ora_rac",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Bert Hajee",
   "summary": "The classed and defined types to install a RAC database",
   "license": "Apache License, Version 2.0",


### PR DESCRIPTION
Changes have been testen and found to work in my setup.

The hostfile register is setup to be compatible with the way we work now.
By adding this to your yaml , you can influence the behavior by preventing the run to register a line in your hostfile ;

ora_rac::params::scan_name_in_hostfile:       false

false would expect the scan_name is registered in DNS.

Profile adjustment is a cosmetic fix to prevent ping pong effects every run.

Please also tag a new version 1.0.4 once accepted.